### PR TITLE
Allow Routes to select TBC zones as well

### DIFF
--- a/Routes/Routes.lua
+++ b/Routes/Routes.lua
@@ -193,7 +193,7 @@ local function processMapChildrenRecursive(parent)
 	end
 end
 
-local WORLD_MAP_ID = 947
+local WORLD_MAP_ID = 946
 processMapChildrenRecursive(WORLD_MAP_ID)
 
 ------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
https://www.curseforge.com/wow/addons/routes?comment=1203 showed how to allow Routes to use the Outland Zones. I've tried it out and can verify it works on my system.